### PR TITLE
Update vite.config.ts for backend url

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     host: "0.0.0.0",
     proxy: {
       "/api": {
-        target: import.meta.env.VITE_API_BASE_URL || "http://localhost:3002",   // backend Rails server
+        target: "http://localhost:3002",   // backend Rails server
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
We can't use import.meta here we need to load the env first and then call env varsity.