### PR TITLE
When viewing the login/forgot/reset pages the top padding is off

### DIFF
--- a/src/pages/Authentication/ForgotPassword.tsx
+++ b/src/pages/Authentication/ForgotPassword.tsx
@@ -48,7 +48,7 @@ const ForgotPassword = () => {
   };
 
   return (
-    <Container className="d-flex justify-content-center mt-xxl-5">
+    <Container className="d-flex justify-content-center mt-5">
       <Col xs={12} md={6} lg={4}>
         <h2 className="text-center">Forgotten Your Password?</h2>
         <Formik

--- a/src/pages/Authentication/Login.tsx
+++ b/src/pages/Authentication/Login.tsx
@@ -57,7 +57,7 @@ const Login: React.FC = () => {
   };
 
   return (
-    <Container className="d-flex justify-content-center mt-xxl-5">
+    <Container className="d-flex justify-content-center mt-5">
       <Col xs={12} md={6} lg={4}>
         <h1 className="text-center">Login</h1>
         <Formik

--- a/src/pages/Authentication/ResetPassword.tsx
+++ b/src/pages/Authentication/ResetPassword.tsx
@@ -76,7 +76,7 @@ const ResetPassword = () => {
   };
 
   return (
-    <Container className="d-flex justify-content-center mt-xxl-5">
+    <Container className="d-flex justify-content-center mt-5">
       <Col xs={12} md={6} lg={4}>
         <h2 className="text-center">Reset Your Password</h2>
         <Formik


### PR DESCRIPTION
Changing from mt-xxl-5 to mt-5 resolves the issue and keeps a top margin of 5

This change also needed to be done on the Login page.  There is a slight variance between Login, Reset and Forgot pages, because we abided by the styling guide to use h2, but Login uses h1.

<img width="858" height="304" alt="image" src="https://github.com/user-attachments/assets/25198f22-9fa3-4e4a-9bd2-2789f80837ed" />
