### PR TITLE
Unified Login Response

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ import NewTeammateAdvertisement from './pages/Student Teams/NewTeammateAdvertise
 import TeammateReview from './pages/Student Teams/TeammateReview';
 import SignupSheet from 'components/SignupSheet/SignupSheet';
 import PartnerAdvertisements from 'components/SignupSheet/PartnerAdvertisements';
+import Duties from "./pages/Duties/Duties";
+import DutyEditor from "./pages/Duties/DutyEditor";
 import ReviewReportPage from "./pages/Reviews/ReviewReportPage";
 function App() {
   const router = createBrowserRouter([
@@ -292,6 +294,14 @@ function App() {
         {
           path: "email_the_author",
           element: <Email_the_author />,
+        },
+        {
+          path: "duties",
+          element: <ProtectedRoute element={<Duties />} leastPrivilegeRole={ROLE.TA} />,
+          children: [
+            { path: "new", element: <DutyEditor mode="create" /> },
+            { path: "edit/:id", element: <DutyEditor mode="update" /> },
+          ],
         },
         {
           path: "student_tasks",

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -131,6 +131,9 @@ const Header: React.FC = () => {
                     <NavDropdown.Item as={Link} to="/questionnaire">
                       Questionnaire
                     </NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/duties">
+                      Roles (Duties)
+                    </NavDropdown.Item>
                     <NavDropdown.Divider />
                     <NavDropdown.Item as={Link} to="/impersonate">
                       Impersonate User

--- a/src/pages/Assignments/AssignmentUtil.ts
+++ b/src/pages/Assignments/AssignmentUtil.ts
@@ -27,6 +27,7 @@ export interface IAssignmentFormValues {
   review_rubric_varies_by_round?: boolean;
   review_rubric_varies_by_topic?: boolean;
   review_rubric_varies_by_role?: boolean;
+  is_role_based?: boolean;
   has_max_review_limit?: boolean;
   set_allowed_number_of_reviews_per_reviewer?: number;
   set_required_number_of_reviews_per_reviewer?: number;
@@ -129,6 +130,7 @@ export const transformAssignmentRequest = (values: IAssignmentFormValues) => {
     review_rubric_varies_by_round: values.review_rubric_varies_by_round ?? false,
     review_rubric_varies_by_topic: values.review_rubric_varies_by_topic ?? false,
     review_rubric_varies_by_role: values.review_rubric_varies_by_role ?? false,
+    is_role_based: values.is_role_based ?? false,
     has_max_review_limit: values.has_max_review_limit ?? false,
     set_allowed_number_of_reviews_per_reviewer: values.set_allowed_number_of_reviews_per_reviewer,
     set_required_number_of_reviews_per_reviewer: values.set_required_number_of_reviews_per_reviewer,
@@ -239,6 +241,7 @@ export const transformAssignmentResponse = (assignmentResponse: string) => {
     review_rubric_varies_by_round:
       assignment.varying_rubrics_by_round ?? assignment.vary_by_round,
     number_of_review_rounds: assignment.num_review_rounds,
+    is_role_based: (assignment as any).is_role_based ?? false,
 
     // precomputed date/time fields for the Due dates tab
     date_time: dateTimeMap as any,

--- a/src/pages/Duties/Duties.tsx
+++ b/src/pages/Duties/Duties.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button, Col, Container, Row } from "react-bootstrap";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import Table from "components/Table/Table";
+import { dutyColumns, IDuty } from "./DutyColumns";
+import useAPI from "../../hooks/useAPI";
+import { alertActions } from "../../store/slices/alertSlice";
+import DutyEditor from "./DutyEditor";
+import DutyDelete from "./DutyDelete";
+import { RootState } from "store/store";
+import { ROLE } from "utils/interfaces";
+
+const Duties = () => {
+    const { data: dutiesRes, error, isLoading, sendRequest: fetchDuties } = useAPI();
+    const { data: usersRes, sendRequest: fetchUsers } = useAPI();
+    const [showEditor, setShowEditor] = useState<{ visible: boolean; mode?: "create" | "update"; initial?: any }>({ visible: false });
+    const [showDelete, setShowDelete] = useState<{ visible: boolean; duty?: IDuty }>({ visible: false });
+
+    const navigate = useNavigate();
+    const dispatch = useDispatch();
+    const location = useLocation();
+    const auth = useSelector((s: RootState) => s.authentication);
+
+    // fetch duties (both public + mine). Support optional search/mine filters later via querystring
+    useEffect(() => {
+        fetchDuties({ url: `/duties` });
+        fetchUsers({ url: `/users` });
+        console.log("Fetching duties...");
+    }, [fetchDuties, fetchUsers, location]);
+    useEffect(() => {
+        if (error) {
+            dispatch(alertActions.showAlert({ variant: "danger", message: error }));
+        }
+    }, [error, dispatch]);
+
+    // map duties with creator name
+    const usersById = useMemo(() => {
+        const arr = usersRes?.data || [];
+        return new Map(arr.map((u: any) => [u.id, u.full_name || u.name || `User #${u.id}`]));
+    }, [usersRes?.data]);
+
+    const allDuties: IDuty[] = useMemo(() => (dutiesRes?.data || []), [dutiesRes?.data]);
+
+    // “By creator” should list MY roles on top
+    const sortWithMineOnTop = useCallback((rows: IDuty[]) => {
+        const myId = auth.user?.id;
+        return [...rows].sort((a, b) => {
+            const aMine = a.instructor_id === myId ? 0 : 1;
+            const bMine = b.instructor_id === myId ? 0 : 1;
+            if (aMine !== bMine) return aMine - bMine; // mine first
+            // default secondary sort by name
+            return (a.name || "").localeCompare(b.name || "");
+        });
+    }, [auth.user?.id]);
+
+    const tableData = useMemo(() => {
+        const userId = auth.user?.id;
+        const filteredDuties = (allDuties || []).filter(d => !d.private || d.instructor_id === userId);
+        console.log("Table Data:", filteredDuties); // Debugging
+        return filteredDuties;
+    }, [allDuties, auth.user?.id]);
+
+    // handlers
+    const onEdit = useCallback((row: any) => {
+        setShowEditor({ visible: true, mode: "update", initial: row.original });
+    }, []);
+    const onDelete = useCallback((row: any) => {
+        setShowDelete({ visible: true, duty: row.original });
+    }, []);
+    const onCloseEditor = useCallback(() => setShowEditor({ visible: false }), []);
+    const onCloseDelete = useCallback(() => setShowDelete({ visible: false }), []);
+
+    const columns = useMemo(() => dutyColumns(onEdit, onDelete), [onEdit, onDelete]);
+
+    return (
+        <>
+            <Outlet />
+            <main>
+                <Container fluid className="px-md-4">
+                    <Row className="mt-4 mb-4">
+                        <Col className="text-center">
+                            <h1 className="text-dark" style={{ fontSize: "2rem", fontWeight: 600 }}>
+                                Manage Duties
+                            </h1>
+                        </Col>
+                    </Row>
+
+                    {/* create new (+) like Courses/Assignments */}
+                    <Row>
+                        <Col md={{ span: 1, offset: 11 }} style={{ paddingBottom: "10px" }}>
+                            <Button variant="outline-success" onClick={() => setShowEditor({ visible: true, mode: "create" })}>
+                                +
+                            </Button>
+                        </Col>
+                    </Row>
+
+                    <Row>
+                        <Table
+                            data={tableData}
+                            columns={columns}
+                            showGlobalFilter={false}
+                            showColumnFilter={true}
+                            showPagination={true}
+                        // your shared Table handles sorting/filtering/pagination/selection/expanders:contentReference[oaicite:4]{index=4}:contentReference[oaicite:5]{index=5}:contentReference[oaicite:6]{index=6}
+                        />
+                    </Row>
+                </Container>
+            </main>
+
+            {showEditor.visible && (
+                <DutyEditor
+                    mode={showEditor.mode!}
+                    initial={showEditor.initial}
+                    onClose={onCloseEditor}
+                    fetchDuties={() => fetchDuties({ url: `/duties` })}
+                />
+            )}
+            {showDelete.visible && showDelete.duty && (
+                <DutyDelete duty={{ id: showDelete.duty.id, name: showDelete.duty.name }} onClose={onCloseDelete} fetchDuties={() => fetchDuties({ url: `/duties` })}  />
+            )}
+        </>
+    );
+};
+
+export default Duties;

--- a/src/pages/Duties/DutyColumns.tsx
+++ b/src/pages/Duties/DutyColumns.tsx
@@ -1,0 +1,50 @@
+import { createColumnHelper, Row } from "@tanstack/react-table";
+import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
+
+export interface IDuty {
+    id: number;
+    name: string;
+    instructor_id: number;
+    private: boolean;
+}
+
+type Fn = (row: Row<IDuty>) => void;
+
+const ch = createColumnHelper<IDuty>();
+
+export const dutyColumns = (handleEdit: Fn, handleDelete: Fn) => [
+    ch.accessor("name", {
+        id: "name",
+        header: () => (
+            <span className="text-start fw-bold" style={{ color: "#000", fontSize: "1.17em" }}>
+                Name
+            </span>
+        ),
+        cell: info => <div className="text-start py-2">{info.getValue()}</div>,
+        enableSorting: true,
+        enableColumnFilter: true,
+        enableGlobalFilter: true,
+    }),
+    ch.display({
+        id: "actions",
+        header: () => (
+            <span className="text-start fw-bold" style={{ color: "#000", fontSize: "1.17em" }}>
+                Actions
+            </span>
+        ),
+        cell: ({ row }) => (
+            <div className="d-flex justify-content-start gap-2 py-2">
+                <OverlayTrigger overlay={<Tooltip>Edit Duty</Tooltip>}>
+                    <Button variant="link" onClick={() => handleEdit(row)} aria-label="Edit Duty" className="p-0">
+                        <img src={"/assets/images/edit-icon-24.png"} alt="Edit" style={{ width: 25, height: 20 }} />
+                    </Button>
+                </OverlayTrigger>
+                <OverlayTrigger overlay={<Tooltip>Delete Duty</Tooltip>}>
+                    <Button variant="link" onClick={() => handleDelete(row)} aria-label="Delete Duty" className="p-0">
+                        <img src={"/assets/images/delete-icon-24.png"} alt="Delete" style={{ width: 25, height: 20 }} />
+                    </Button>
+                </OverlayTrigger>
+            </div>
+        ),
+    }),
+];

--- a/src/pages/Duties/DutyDelete.tsx
+++ b/src/pages/Duties/DutyDelete.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { Modal, Button } from "react-bootstrap";
+import useAPI from "../../hooks/useAPI";
+import { useDispatch } from "react-redux";
+import { alertActions } from "../../store/slices/alertSlice";
+
+const DutyDelete: React.FC<{ duty: { id: number; name: string }; onClose: () => void; fetchDuties: () => void }> = ({
+    duty,
+    onClose,
+    fetchDuties,
+}) => {
+    const { sendRequest } = useAPI();
+    const dispatch = useDispatch();
+
+    const [localError, setLocalError] = useState<string | null>(null);
+    const [show, setShow] = useState(true);
+
+    const deleteHandler = async () => {
+        try {
+            await sendRequest({ url: `/duties/${duty.id}`, method: "DELETE" });
+            setShow(false);
+            setLocalError(null);
+            fetchDuties(); // Refresh the duties table
+            dispatch(alertActions.showAlert({ variant: "success", message: `Duty ${duty.name} deleted successfully!` }));
+            onClose();
+        } catch (err: any) {
+            setLocalError(err.message || "Failed to delete duty");
+        }
+    };
+
+    const closeHandler = () => {
+        setShow(false);
+        onClose();
+    };
+
+    return (
+        <Modal show={show} onHide={closeHandler} centered>
+            <Modal.Header closeButton>
+                <Modal.Title>Delete Duty</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {localError && <div className="alert alert-danger">{localError}</div>}
+                Are you sure you want to delete <b>{duty.name}</b>?
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="outline-secondary" onClick={closeHandler}>
+                    Cancel
+                </Button>
+                <Button variant="outline-danger" onClick={deleteHandler}>
+                    Delete
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default DutyDelete;

--- a/src/pages/Duties/DutyEditor.tsx
+++ b/src/pages/Duties/DutyEditor.tsx
@@ -1,0 +1,134 @@
+import { Form as FormikForm, Formik, FormikHelpers } from "formik";
+import * as Yup from "yup";
+import { Button, Modal, Form as RBForm } from "react-bootstrap";
+import { useDispatch } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
+import useAPI from "../../hooks/useAPI";
+import FormInput from "components/Form/FormInput";
+import { alertActions } from "../../store/slices/alertSlice";
+import { HttpMethod } from "utils/httpMethods";
+import React, { useState } from "react";
+
+export interface IDutyFormValues {
+    id?: number;
+    name: string;
+    private: boolean;
+}
+
+const schema = Yup.object({
+    name: Yup.string().required("Required").min(3, "Min 3 chars").max(50, "Max 50 chars"),
+});
+
+type DutyEditorProps = {
+    mode: "create" | "update";
+    initial?: { id?: number; name?: string; private?: boolean };
+    onClose?: () => void;
+    fetchDuties?: () => void;
+};
+
+const DutyEditor: React.FC<DutyEditorProps> = ({ mode, initial, onClose, fetchDuties }) => {
+    const { sendRequest } = useAPI();
+    const dispatch = useDispatch();
+    const navigate = useNavigate();
+
+    const [localError, setLocalError] = useState<string | null>(null);
+
+    const onSubmit = async (values: IDutyFormValues, helpers: FormikHelpers<IDutyFormValues>) => {
+        const payload = {
+            name: values.name,
+            private: values.private,
+        };
+        const url = mode === "create" ? "/duties" : `/duties/${initial?.id}`;
+        const method = mode === "create" ? "POST" : "PATCH";
+
+        try {
+            await sendRequest({ url, method, data: { duty: payload } });
+            helpers.setSubmitting(false);
+            setLocalError(null);
+            if (fetchDuties) {
+                fetchDuties(); // Refresh the duties table when provided
+            }
+            dispatch(
+                alertActions.showAlert({
+                    variant: "success",
+                    message: mode === "create" ? "New duty created successfully!" : "Duty updated successfully!",
+                })
+            );
+            if (onClose) {
+                onClose(); // Close the modal when used as a child component
+            } else {
+                navigate("/duties"); // Fallback when used as a route
+            }
+        } catch (err: any) {
+            setLocalError(err.message || "An error occurred");
+            helpers.setSubmitting(false);
+        }
+    };
+
+    const handleClose = () => {
+        if (onClose) {
+            onClose();
+        } else {
+            navigate("/duties");
+        }
+    };
+
+    return (
+        <Modal size="lg" centered show={true} onHide={handleClose} backdrop="static">
+            <Modal.Header closeButton>
+                <Modal.Title>{mode === "update" ? "Edit Duty" : "Create Duty"}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                {localError && <div className="alert alert-danger">{localError}</div>}
+                <Formik
+                    initialValues={{
+                        name: initial?.name || "",
+                        private: initial?.private || false,
+                    }}
+                    validationSchema={schema}
+                    onSubmit={onSubmit}
+                >
+                    {({ values, handleChange, handleSubmit, handleBlur, isSubmitting, errors, touched }) => (
+                        <form onSubmit={handleSubmit}>
+                            <div className="mb-3">
+                                <label htmlFor="name" className="form-label">
+                                    Name
+                                </label>
+                                <input
+                                    type="text"
+                                    id="name"
+                                    name="name"
+                                    className={`form-control${errors.name && touched.name ? " is-invalid" : ""}`}
+                                    value={values.name}
+                                    onChange={handleChange}
+                                    onBlur={handleBlur}
+                                />
+                                {errors.name && touched.name && (
+                                    <div className="invalid-feedback">{errors.name}</div>
+                                )}
+                            </div>
+                            <div className="mb-3 form-check">
+                                <input
+                                    type="checkbox"
+                                    id="private"
+                                    name="private"
+                                    className="form-check-input"
+                                    checked={values.private}
+                                    onChange={handleChange}
+                                />
+                                <label htmlFor="private" className="form-check-label">
+                                    Private
+                                </label>
+                            </div>
+                            <Button type="submit" variant="primary" disabled={isSubmitting}>
+                                {mode === "update" ? "Update Duty" : "Create Duty"}
+                            </Button>
+                        </form>
+                    )}
+                </Formik>
+            </Modal.Body>
+        </Modal>
+    );
+};
+
+export default DutyEditor;

--- a/src/pages/Duties/DutyUtil.ts
+++ b/src/pages/Duties/DutyUtil.ts
@@ -1,0 +1,13 @@
+export type DutyFormValues = {
+  id?: number;
+  name: string;
+  visibility: string[];        // <-- array for FormCheckBoxGroup
+  instructor_id?: number;
+};
+
+export const toBooleanPrivate = (visibility: string[]) => visibility?.includes("true");
+
+export const transformDutyRequest = (data: DutyFormValues) => {
+  const privateFlag = toBooleanPrivate(data.visibility);
+  return { duty: { name: data.name, private: privateFlag, instructor_id: data.instructor_id } };
+};

--- a/src/pages/OidcCallback/OidcCallback.tsx
+++ b/src/pages/OidcCallback/OidcCallback.tsx
@@ -37,7 +37,7 @@ const OidcCallback: React.FC = () => {
     axios
       .post("http://localhost:3002/auth/callback", { code, state })
       .then((response) => {
-        const payload = setAuthToken(response.data.session_token);
+        const payload = setAuthToken(response.data.token);
 
         localStorage.setItem("session", JSON.stringify({ user: payload }));
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,11 @@
+export const EVENTS = {
+  DUTIES_CHANGED: "duties:changed",
+} as const;
+
+// convenience helpers (optional)
+export const emit = (name: string, detail?: unknown) =>
+  window.dispatchEvent(new CustomEvent(name, { detail }));
+export const on = (name: string, handler: EventListener) => {
+  window.addEventListener(name, handler);
+  return () => window.removeEventListener(name, handler);
+};


### PR DESCRIPTION
As a developer, I want the session object returned to the frontend clearly defined and reusable by all login flows, so that the frontend can rely on a consistent response shape regardless of authentication method.

Acceptance Criteria:

Extract the JWT payload construction and token issuance logic from AuthenticationController#login and OidcLoginController#callback into a shared method on the User model (e.g. user.generate_jwt).
Define a consistent response structure (e.g. { token, user: { id, name, full_name, role, institution_id } }) and use it in both controllers.
Update the existing password login endpoint to use the shared method without changing its external response shape.
Add or update request specs for both login endpoints to assert the response structure matches.