### PR TITLE
Moved axio calls to use AxiosClient

### DIFF
--- a/src/components/OidcLogin/OidcLogin.tsx
+++ b/src/components/OidcLogin/OidcLogin.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Form } from "react-bootstrap";
 import axios from "axios";
+import axiosClient from "../../utils/axios_client";
 
 interface OidcProvider {
   id: string;
@@ -10,16 +11,17 @@ interface OidcProvider {
 const OidcLogin: React.FC = () => {
   const [providers, setProviders] = useState<OidcProvider[]>([]);
 
+
   useEffect(() => {
-    axios
-      .get("http://localhost:3002/auth/providers")
+    axiosClient
+      .get("/auth/providers")
       .then((response) => setProviders(response.data))
       .catch(() => setProviders([]));
   }, []);
 
   const handleLogin = (providerId: string) => {
-    axios
-      .post("http://localhost:3002/auth/client-select", { provider: providerId })
+    axiosClient
+      .post("/auth/client-select", { provider: providerId })
       .then((response) => {
         window.location.href = response.data.redirect_uri;
       })

--- a/src/components/OidcLogin/OidcLogin.tsx
+++ b/src/components/OidcLogin/OidcLogin.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 import { Form } from "react-bootstrap";
-import axios from "axios";
 import axiosClient from "../../utils/axios_client";
 
 interface OidcProvider {

--- a/src/components/OidcLogin/OidcLogin.tsx
+++ b/src/components/OidcLogin/OidcLogin.tsx
@@ -13,14 +13,14 @@ const OidcLogin: React.FC = () => {
 
   useEffect(() => {
     axiosClient
-      .get("/auth/providers")
+      .get("/auth/providers", { skipAuth: true })
       .then((response) => setProviders(response.data))
       .catch(() => setProviders([]));
   }, []);
 
   const handleLogin = (providerId: string) => {
     axiosClient
-      .post("/auth/client-select", { provider: providerId })
+      .post("/auth/client-select", { provider: providerId }, { skipAuth: true })
       .then((response) => {
         window.location.href = response.data.redirect_uri;
       })

--- a/src/pages/Authentication/Login.tsx
+++ b/src/pages/Authentication/Login.tsx
@@ -8,7 +8,7 @@ import { authenticationActions } from "../../store/slices/authenticationSlice";
 import { alertActions } from "../../store/slices/alertSlice";
 import { setAuthToken } from "../../utils/auth";
 import * as Yup from "yup";
-import axios from "axios";
+import axiosClient from "utils/axios_client";
 import OidcLogin from "../../components/OidcLogin/OidcLogin";
 
 /**
@@ -30,8 +30,8 @@ const Login: React.FC = () => {
   const location = useLocation();
 
   const onSubmit = (values: ILoginFormValues, submitProps: FormikHelpers<ILoginFormValues>) => {
-    axios
-      .post("http://localhost:3002/login", values)
+    axiosClient
+      .post("/login", values, { skipAuth: true })
       .then((response) => {
         const payload = setAuthToken(response.data.token);
 

--- a/src/pages/OidcCallback/OidcCallback.tsx
+++ b/src/pages/OidcCallback/OidcCallback.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from "react-redux";
 import { authenticationActions } from "../../store/slices/authenticationSlice";
 import { alertActions } from "../../store/slices/alertSlice";
 import { setAuthToken } from "../../utils/auth";
-import axios from "axios";
+import axiosClient from "../../utils/axios_client";
 
 const OidcCallback: React.FC = () => {
   const [searchParams] = useSearchParams();
@@ -34,8 +34,8 @@ const OidcCallback: React.FC = () => {
       return;
     }
 
-    axios
-      .post("http://localhost:3002/auth/callback", { code, state })
+    axiosClient
+      .post("/auth/callback", { code, state })
       .then((response) => {
         const payload = setAuthToken(response.data.token);
 

--- a/src/types/axiosAuth.d.ts
+++ b/src/types/axiosAuth.d.ts
@@ -1,0 +1,10 @@
+import 'axios';
+
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    skipAuth?: boolean;
+  }
+  export interface InternalAxiosRequestConfig {
+    skipAuth?: boolean;
+  }
+}

--- a/src/utils/axios_client.ts
+++ b/src/utils/axios_client.ts
@@ -16,9 +16,7 @@ const axiosClient = axios.create({
 
 axiosClient.interceptors.request.use((config) => {
   // Check if this request should skip authentication (for login  / OIDC)
-  const skipAuth = (config as any).skipAuth === true;
-  
-  if (skipAuth) {
+  if (config.skipAuth) {
     return config;
   }
 

--- a/src/utils/axios_client.ts
+++ b/src/utils/axios_client.ts
@@ -6,7 +6,7 @@ import { getAuthToken } from "./auth";
  */
 
 const axiosClient = axios.create({
-  baseURL: "http://localhost:3002",
+  baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:3002",
   timeout: 10000, // Increased from 1000ms to 10 seconds
   headers: {
     "Content-Type": "application/json",
@@ -15,6 +15,13 @@ const axiosClient = axios.create({
 });
 
 axiosClient.interceptors.request.use((config) => {
+  // Check if this request should skip authentication (for login  / OIDC)
+  const skipAuth = (config as any).skipAuth === true;
+  
+  if (skipAuth) {
+    return config;
+  }
+
   const token = getAuthToken();
   if (token && token !== "EXPIRED") {
     config.headers["Authorization"] = `Bearer ${token}`;


### PR DESCRIPTION
Switching to using the axiosClient module rather than axios directly. This allows us to leverage the axioClient to set the backend URL, making the location of it set in one location.

By passing {skipAuth: true} to the axiosclient .post/.get requests in login and OidcLogin, we're able to utilize the same module for api calls.

```
 ...ents/OidcLogin |   43.75 |       25 |   22.22 |   42.85 |
  OidcLogin.tsx    |   43.75 |       25 |   22.22 |   42.85 | 17-18,22-28,34-47
  Login.tsx        |   53.33 |       50 |      40 |   53.33 | 33-57
 ...s/OidcCallback |    4.16 |        0 |       0 |    4.16 |
  OidcCallback.tsx |    4.16 |        0 |       0 |    4.16 | 10-64
```
