### PR TITLE
adding skipAuth to callback

### DIFF
--- a/src/pages/OidcCallback/OidcCallback.tsx
+++ b/src/pages/OidcCallback/OidcCallback.tsx
@@ -35,7 +35,7 @@ const OidcCallback: React.FC = () => {
     }
 
     axiosClient
-      .post("/auth/callback", { code, state })
+      .post("/auth/callback", { code, state }, { skipAuth: true })
       .then((response) => {
         const payload = setAuthToken(response.data.token);
 


### PR DESCRIPTION
During the oidc callbacks we needed to ensure that skipAuth is enabled.

This makes sure that we don't need to be authed for this endpoint as of this step.