### PR TITLE
Callback Route and Login Completion

### DIFF
--- a/src/pages/OidcCallback/OidcCallback.test.tsx
+++ b/src/pages/OidcCallback/OidcCallback.test.tsx
@@ -184,17 +184,17 @@ describe("OidcCallback", () => {
   it("shows error parameter in URL query and does not make API call", async () => {
     renderCallback(`${CALLBACK_ROUTE}?error=access_denied`, false);
 
-    // No backend call made
+    // Wait for the redirect — the real observable side effect in this branch
     await waitFor(() => {
-      expect(vi.mocked(axiosClient).post).not.toHaveBeenCalled();
+      expect(screen.getByText("Login")).toBeInTheDocument();
     });
+
+    // After the full useEffect has run, the backend should never have been called
+    expect(vi.mocked(axiosClient).post).not.toHaveBeenCalled();
 
     // Alert was dispatched with the provider error value
     expect(store.getState().alert.show).toBe(true);
     expect(store.getState().alert.variant).toBe("danger");
     expect(store.getState().alert.message).toContain("access_denied");
-
-    // Redirected to login
-    expect(screen.getByText("Login")).toBeInTheDocument();
   });
 });

--- a/src/pages/OidcCallback/OidcCallback.test.tsx
+++ b/src/pages/OidcCallback/OidcCallback.test.tsx
@@ -154,19 +154,15 @@ describe("OidcCallback", () => {
 
     renderCallback(CALLBACK_URL, false);
 
+    // Wait for the redirect — confirms the catch block fully ran
     await waitFor(() => {
-      expect(vi.mocked(axiosClient).post).toHaveBeenCalled();
+      expect(screen.getByText("Login")).toBeInTheDocument();
     });
 
     // Alert was dispatched with the backend error message
-    await waitFor(() => {
-      expect(store.getState().alert.show).toBe(true);
-    });
+    expect(store.getState().alert.show).toBe(true);
     expect(store.getState().alert.variant).toBe("danger");
     expect(store.getState().alert.message).toBe(MOCK_ERROR_RESPONSE.error);
-
-    // Redirected to login
-    expect(screen.getByText("Login")).toBeInTheDocument();
   });
 
   it("handles network timeout during callback", async () => {

--- a/src/pages/OidcCallback/OidcCallback.test.tsx
+++ b/src/pages/OidcCallback/OidcCallback.test.tsx
@@ -117,8 +117,18 @@ describe("OidcCallback", () => {
       expect(vi.mocked(authUtils.setAuthToken)).toHaveBeenCalledWith(MOCK_JWT_TOKEN);
     }, { timeout: 3000 });
 
+    // localStorage session was persisted
     const session = JSON.parse(localStorage.getItem("session") || "{}");
     expect(session.user).toBeDefined();
+
+    // Redux received the correct token
+    expect(store.getState().authentication.authToken).toBe(MOCK_JWT_TOKEN);
+    expect(store.getState().authentication.user).toEqual(MOCK_AUTH_PAYLOAD);
+
+    // Navigated to the dashboard
+    await waitFor(() => {
+      expect(screen.getByText("Home")).toBeInTheDocument();
+    });
   });
 
   it("does not make API call when missing code", async () => {

--- a/src/pages/OidcCallback/OidcCallback.test.tsx
+++ b/src/pages/OidcCallback/OidcCallback.test.tsx
@@ -174,8 +174,17 @@ describe("OidcCallback", () => {
   it("shows error parameter in URL query and does not make API call", async () => {
     renderCallback(`${CALLBACK_ROUTE}?error=access_denied`, false);
 
+    // No backend call made
     await waitFor(() => {
       expect(vi.mocked(axiosClient).post).not.toHaveBeenCalled();
     });
+
+    // Alert was dispatched with the provider error value
+    expect(store.getState().alert.show).toBe(true);
+    expect(store.getState().alert.variant).toBe("danger");
+    expect(store.getState().alert.message).toContain("access_denied");
+
+    // Redirected to login
+    expect(screen.getByText("Login")).toBeInTheDocument();
   });
 });

--- a/src/pages/OidcCallback/OidcCallback.test.tsx
+++ b/src/pages/OidcCallback/OidcCallback.test.tsx
@@ -157,6 +157,16 @@ describe("OidcCallback", () => {
     await waitFor(() => {
       expect(vi.mocked(axiosClient).post).toHaveBeenCalled();
     });
+
+    // Alert was dispatched with the backend error message
+    await waitFor(() => {
+      expect(store.getState().alert.show).toBe(true);
+    });
+    expect(store.getState().alert.variant).toBe("danger");
+    expect(store.getState().alert.message).toBe(MOCK_ERROR_RESPONSE.error);
+
+    // Redirected to login
+    expect(screen.getByText("Login")).toBeInTheDocument();
   });
 
   it("handles network timeout during callback", async () => {

--- a/src/pages/OidcCallback/OidcCallback.tsx
+++ b/src/pages/OidcCallback/OidcCallback.tsx
@@ -43,7 +43,7 @@ const OidcCallback: React.FC = () => {
 
         dispatch(
           authenticationActions.setAuthentication({
-            authToken: response.data.session_token,
+            authToken: response.data.token,
             user: payload,
           })
         );


### PR DESCRIPTION
### This PR addresses this [user story](https://github.com/users/johnmweisz/projects/8/views/1?pane=issue&itemId=173822086&issue=johnmweisz%7Creimplementation-front-end%7C23).

## Fix OIDC callback token bug and strengthen test coverage

### Bug Fix

`OidcCallback` dispatched `response.data.session_token` (which doesn't exist) to Redux, causing `authToken` to be `undefined` after every OIDC login. Fixed to use `response.data.token`, matching the password login flow in `Login.tsx`.

### Test Improvements

Three tests were only asserting partial behavior. Added assertions for:
- **Success**: Redux `authToken` equals the JWT, user payload is correct, redirects to `/`
- **Provider error**: danger alert dispatched with the error value, redirects to `/login`
- **Backend error**: danger alert dispatched with `error.response.data.error`, redirects to `/login`

### Files Changed
- `src/pages/OidcCallback/OidcCallback.tsx` — 1 line fix
- `src/pages/OidcCallback/OidcCallback.test.tsx` — strengthened 3 tests

### All tests pass
<img width="1782" height="1105" alt="image" src="https://github.com/user-attachments/assets/aafd7fb6-a164-4bd8-8cbf-b985cbaa9d57" />
